### PR TITLE
Fix_data-logger

### DIFF
--- a/code/Logging/DataLogger.py
+++ b/code/Logging/DataLogger.py
@@ -5,22 +5,22 @@ from pathlib import Path
 class DataLogger:
     DEF_HEADERS = ['Data']
 
-    def __init__(self, file, headers=DEF_HEADERS, overwrite=True):
-        self._file = Path(file)
-        self._headers = headers
-        self._columns = len(headers)
+    def __init__(self, file, headers=None):
+        self._file = Path(file).resolve()
+        self._headers = headers or DataLogger.DEF_HEADERS
 
-        try:
-            with open(self._file, 'w', newline='') as file:
+        self._file.parent.mkdir(parents=True, exist_ok=True)
+        self._file.touch()
+
+        if headers:
+            with self._file.open('w', newline='') as file:
                 writer = csv.writer(file, delimiter=',')
                 writer.writerow(headers)
-        except IOError as e:
-            print(f"IOError: {e}")
 
 
     @property
     def columns(self):
-        return self._columns
+        return len(self._headers)
 
     @property
     def file(self):
@@ -31,12 +31,14 @@ class DataLogger:
         return self._headers
 
 
-    def log_data(self, data):
-        try:
-            with open(self._file, 'a', newline='') as file:
-                writer = csv.writer(file, delimiter=',')
-                writer.writerow(data)
-            return data
-        except IOError as e:
-            print(f"IOError: {e}")
-            return None
+    def log(self, *args):
+        data = [args] if len(args) == 1 else args
+
+        with open(self._file, 'a', newline='') as file:
+            writer = csv.writer(file, delimiter=',')
+            for entry in data:
+                if len(entry) == len(self._headers): 
+                    writer.writerow(entry)
+                else:
+                    raise ValueError('Data length does not match headers length')
+        return data

--- a/code/Logging/DataLogger.py
+++ b/code/Logging/DataLogger.py
@@ -1,13 +1,17 @@
 import csv
+from pathlib import Path
 
 
 class DataLogger:
-    def __init__(self, file_name, headers=[]):
-        self._file_name = file_name
+    DEF_HEADERS = ['Data']
+
+    def __init__(self, file, headers=DEF_HEADERS, overwrite=True):
+        self._file = Path(file)
+        self._headers = headers
         self._columns = len(headers)
-        
+
         try:
-            with open(self._file_name, 'w', newline='') as file:
+            with open(self._file, 'w', newline='') as file:
                 writer = csv.writer(file, delimiter=',')
                 writer.writerow(headers)
         except IOError as e:
@@ -19,24 +23,17 @@ class DataLogger:
         return self._columns
 
     @property
-    def file_name(self):
-        return self._file_name
+    def file(self):
+        return self._file
 
     @property
     def headers(self):
-        try:
-            with open(self._file_name, 'r') as file:
-                reader = csv.reader(file, delimiter=',')
-                headers = next(reader)
-            return headers
-        except IOError as e:
-            print(f"IOError: {e}")
-            return None
+        return self._headers
 
 
     def log_data(self, data):
         try:
-            with open(self._file_name, 'a', newline='') as file:
+            with open(self._file, 'a', newline='') as file:
                 writer = csv.writer(file, delimiter=',')
                 writer.writerow(data)
             return data

--- a/code/Logging/DataLogger.py
+++ b/code/Logging/DataLogger.py
@@ -12,10 +12,9 @@ class DataLogger:
         self._file.parent.mkdir(parents=True, exist_ok=True)
         self._file.touch()
 
-        if headers:
-            with self._file.open('w', newline='') as file:
-                writer = csv.writer(file, delimiter=',')
-                writer.writerow(headers)
+        with self._file.open('w', newline='') as file:
+            writer = csv.writer(file, delimiter=',')
+            writer.writerow(headers)
 
 
     @property

--- a/code/Tests/DataLogger_test.py
+++ b/code/Tests/DataLogger_test.py
@@ -1,99 +1,126 @@
 from Logging.DataLogger import DataLogger
-from pathlib import Path as P
+from pathlib import Path
 import csv
 import pytest
 
 
-@pytest.fixture(params=['tmp_log.csv', 'tmp log.csv', 'a.csv', 'a', 'a/'])
-def tmp_files(tmp_path, request):
-    return tmp_path / request.param
+class SampleLog:
+    def __init__(self, *args):
+        match len(args):
+            case 1: self._rows = args[0]
+            case 2: self._rows = args[0] + args[1]
+            case _: self._rows = args
+        
+    @property
+    def headers(self): return self._rows[0]
+
+    @property
+    def data(self): return self._rows[1:]
+
+    @property
+    def rows(self): return self._rows
+
+
+SAMPLES = {
+    'default': SampleLog(
+        DataLogger.DEF_HEADERS, 
+        [1.234],
+        [5.678],
+    ),
+    'gps': SampleLog(
+        ['Time', 'Latitude', 'Longitude', 'Altitude'],
+        ['2019-01-01 00:00:00', 1.234, 5.678, 912],
+        ['2019-01-01 00:00:30', 2.345, 6.789, 123],
+    ),
+    'time_data': SampleLog(
+        ['Time', 'Data'],
+        ['2019-01-01 00:00:00', 1.234],
+        ['2019-01-01 00:00:30', 5.678],
+    ),
+    'subjects': SampleLog(
+        ['English', 'Spanish', 'Math', 'Physics', 'Chemistry'],
+        ['0:00', '0:30', '1:30', '1:00', '1:00'],
+        ['0:05', '0:00', '0:00', '3:00', '1:00'],
+        ['0:00', '0:30', '0:30', '0:00', '0:30'],
+    ),
+}
+
+TYPES = SAMPLES.keys()
+
+FILE_CASES = {
+    'simple': ['tmp.csv', 0],
+    'single': ['a', 1],
+    'inner':  ['inner/tmp.csv', 0],
+    'inner2': ['in1/in2/tmp.csv', 0],
+    'in_ner': ['in ner/tmp.csv', 1],
+}
+
+
+@pytest.fixture(params=['default'])
+def sample(request):
+    return SAMPLES[request.param]
 
 @pytest.fixture
-def tmp_file(tmp_path):
-    return tmp_path / 'tmp_log.csv'
-
-@pytest.fixture(params=[P('inner') / 'tmp.csv', P('in1') / 'in2' / 'tmp_log.csv'])
-def tmp_files_inner(tmp_path, request):
-    return tmp_path / request.param
+def headers(sample, request):
+    return SAMPLES[request.param].headers if hasattr(request, 'param') else sample.headers
 
 @pytest.fixture
-def headers_def():
-    return DataLogger.DEF_HEADERS
+def data(sample, request):
+    return SAMPLES[request.param].data if hasattr(request, 'param') else sample.data
 
-@pytest.fixture(params=[
-    ['Time', 'Data'],
-    ['Time', 'Latitude', 'Longitude', 'Altitude'],
-    ['Account', 'Balance'],
-    ['English', 'Spanish', 'Math', 'Physics', 'Chemistry', 'History'],
-])
-def headers(request):
-    return request.param
+@pytest.fixture(params=['simple'])
+def tmp_file(tmp_path, request):
+    file, exist = FILE_CASES[request.param]
+    tmp_file = tmp_path / file
 
-@pytest.fixture
-def logger_def(tmp_file):
-    return DataLogger(tmp_file)
+    match exist: # Will the file exist?
+        case (True | 1): # File will exist
+            tmp_file.parent.mkdir(parents=True, exist_ok=True)
+            tmp_file.touch()
+        case (False | 0): # File will not exist
+            if tmp_file.exists(): tmp_file.unlink()
+        case -1: # File's parent directory will not exist
+            if tmp_file.exists(): tmp_file.unlink()
+            if tmp_file.parent.is_dir(): tmp_file.parent.remove()
+
+    yield tmp_file
+    tmp_file.unlink() # Delete the file after use
 
 @pytest.fixture
 def logger(tmp_file, headers):
     return DataLogger(tmp_file, headers)
 
 
-def test_init(tmp_file):
-    """ Test that the logger is initialized """
-    assert DataLogger(tmp_file), 'Logger not initialized'
-
-
-def test_file_property(tmp_files):
-    """ Test that the file property is set correctly """
-    logger = DataLogger(tmp_files)
-    assert logger.file == tmp_files
-
-
-def test_def_properties(logger_def, headers_def):
-    """ Test that the default properties are set correctly """
-    assert logger_def.headers == headers_def
-    assert logger_def.columns == len(headers_def)
-
-
-def test_set_properties(logger, headers):
-    """ Test that the properties can be set at initialization """
+def test_init(tmp_file, headers):
+    """ Test that the logger is initialized with the right properties"""
+    logger = DataLogger(tmp_file)
+    assert logger, 'Logger not initialized'
     assert logger.headers == headers
     assert logger.columns == len(headers)
 
 
-def test_new_file(tmp_files):
-    """ Test that the logger can create a new file """
-    if tmp_files.exists(): tmp_files.unlink()
-    logger_def = DataLogger(tmp_files)
-    assert logger_def.file.is_file()
+@pytest.mark.parametrize("tmp_file", FILE_CASES.keys(), indirect=True)
+def test_file_creation(tmp_file):
+    """ Test that the file is set up correctly """
+    logger = DataLogger(tmp_file)
+    assert logger.file == Path(tmp_file).resolve(), 'Path property not set correctly'
+    assert logger.file.is_file(), 'File not created'
 
 
-def test_existing_file(tmp_files):
-    """ Test that the logger can read an existing file """
-    tmp_files.touch()
-    logger = DataLogger(tmp_files)
-    assert logger.file.is_file()
-
-
-def test_new_dir(tmp_files_inner, headers):
-    """ Test that a new directory is created if it doesn't exist """
-    logger = DataLogger(tmp_files_inner, headers)
-    assert logger.file.is_file()
-
-
-def test_log_data(logger):
-    """" Test that data can be logged """
-    test_data = ['2019-01-01 00:00:00', 1.234]
-
-    logger.log_data(test_data)
-
-    with open(logger.file_name, 'r') as file:
+@pytest.mark.parametrize("sample", TYPES, indirect=True)
+def test_write_headers(logger, headers):
+    """ Test that the headers are written correctly """
+    with logger.file.open('r') as file:
         reader = csv.reader(file, delimiter=',')
-        _ = next(reader) # skip headers
-        data = next(reader)
-
-    assert data == [str(i) for i in test_data] # Convert data to strings before comparing
+        assert next(reader) == headers, 'Headers not written correctly'
 
 
-if __name__ == '__main__':
-    pass
+@pytest.mark.parametrize("sample", TYPES, indirect=True)
+def test_log_data(logger, sample):
+    """" Test that data can be logged """
+    for entry in sample.data: logger.log(entry)
+
+    with logger.file.open('r') as file:
+        reader = csv.reader(file, delimiter=',')
+        for i, row in enumerate(reader):
+            assert row == [str(j) for j in sample.rows[i]]

--- a/code/Tests/DataLogger_test.py
+++ b/code/Tests/DataLogger_test.py
@@ -15,7 +15,22 @@ def logger(tmp_file):
 
 
 def test_init_properties(tmp_file):
-    """ Test that the logger is initialized properly and that properties can be accessed """
+    """ Test that the logger is initialized """
+    logger = DataLogger(tmp_file)
+
+    assert logger.file_name == tmp_file
+
+
+def test_init_headers(tmp_file):
+    """ Test that the logger is initialized and headers logged """
+    logger = DataLogger(tmp_file, test_headers)
+    assert logger.headers == test_headers
+
+
+def test_init_new_dir(tmp_path):
+    """ Test that a new directory is created if it doesn't exist """
+    tmp_file = tmp_path / 'tmp_dir' / 'tmp_log.csv'
+
     logger = DataLogger(tmp_file, test_headers)
 
     assert logger.file_name == tmp_file

--- a/code/requirements.txt
+++ b/code/requirements.txt
@@ -1,5 +1,8 @@
 bmp280==0.0.4
+matplotlib==3.5.1
 picamera==1.13
+pynmea2==1.18.0
 pyserial==3.5
+pytest==6.2.5
 smbus==1.1.post2
 smbus2==0.4.1


### PR DESCRIPTION
Fixed cases where file is in a non-existent directory.

Renamed properties
Renamed DataLogger.log_data() to DataLogger.log()

Skip reading the file every time you want to get .headers property: it is now stored in ._headers.

DataLogger.log() now checks if the data passed is of the right length.
DataLogger.log() can now log multiple lines at once if you just pass them all as arguments.

Updated tests.
